### PR TITLE
Added boot_loader as new option

### DIFF
--- a/distro.go
+++ b/distro.go
@@ -33,6 +33,7 @@ type Distro struct {
 	Arch              string   `mapstructure:"arch"`
 	Breed             string   `mapstructure:"breed"`
 	BootFiles         string   `mapstructure:"boot_files"`
+	BootLoader        string   `mapstructure:"boot_loader"`
 	Comment           string   `mapstructure:"comment"`
 	FetchableFiles    string   `mapstructure:"fetchable_files"`
 	Kernel            string   `mapstructure:"kernel"`

--- a/system.go
+++ b/system.go
@@ -37,6 +37,7 @@ type System struct {
 	Autoinstall       string                 `mapstructure:"autoinstall"`
 	AutoinstallMeta   string                 `mapstructure:"autoinstall_meta"`
 	BootFiles         string                 `mapstructure:"boot_files"`
+	BootLoader        string                 `mapstructure:"boot_loader"`
 	Comment           string                 `mapstructure:"comment"`
 	EnableGPXE        bool                   `mapstructure:"enable_gpxe"`
 	FetchableFiles    string                 `mapstructure:"fetchable_files"`


### PR DESCRIPTION
The `boot_loader` option was added to Cobbler 3.x:
```
  --boot-loader=BOOT_LOADER
                        Boot loader (Network installation boot loader) (valid
                        options: <<inherit>>,grub,pxelinux,yaboot,ipxe)
```
Added since it was missing.