### PR TITLE
Fix tests

### DIFF
--- a/fixtures/create-snippet-req.xml
+++ b/fixtures/create-snippet-req.xml
@@ -9,11 +9,6 @@
     </param>
     <param>
       <value>
-        <boolean>0</boolean>
-      </value>
-    </param>
-    <param>
-      <value>
         <string>sample content</string>
       </value>
     </param>

--- a/fixtures/create-template-file-req.xml
+++ b/fixtures/create-template-file-req.xml
@@ -9,11 +9,6 @@
     </param>
     <param>
       <value>
-        <boolean>0</boolean>
-      </value>
-    </param>
-    <param>
-      <value>
         <string>sample content</string>
       </value>
     </param>

--- a/fixtures/get-distros-res.xml
+++ b/fixtures/get-distros-res.xml
@@ -28,8 +28,8 @@
                 <member>
                   <name>kernel_options_post</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -41,8 +41,8 @@
                 <member>
                   <name>kernel_options</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -66,8 +66,8 @@
                 <member>
                   <name>template_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -86,8 +86,8 @@
                 <member>
                   <name>boot_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -114,8 +114,8 @@
                 <member>
                   <name>fetchable_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>

--- a/fixtures/get-profiles-res.xml
+++ b/fixtures/get-profiles-res.xml
@@ -31,24 +31,21 @@
                 <member>
                   <name>autoinstall_meta</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
                   <name>kernel_options_post</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
-                  <name>repos</name>
+                  <name>repo</name>
                   <value>
-                    <array>
-                      <data>
-</data>
-                    </array>
+                    <string>Ubuntu-18.04-x86_64</string>
                   </value>
                 </member>
                 <member>
@@ -66,8 +63,8 @@
                 <member>
                   <name>kernel_options</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -91,8 +88,8 @@
                 <member>
                   <name>template_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -122,8 +119,8 @@
                 <member>
                   <name>boot_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>
@@ -180,8 +177,8 @@
                 <member>
                   <name>fetchable_files</name>
                   <value>
-                    <struct>
-</struct>
+                    <string>
+</string>
                   </value>
                 </member>
                 <member>

--- a/fixtures/get-repos-res.xml
+++ b/fixtures/get-repos-res.xml
@@ -16,7 +16,7 @@
                         <member>
                            <name>environment</name>
                            <value>
-                              <struct />
+                              <string />
                            </value>
                         </member>
                         <member>

--- a/fixtures/get-snippet-req.xml
+++ b/fixtures/get-snippet-req.xml
@@ -9,16 +9,6 @@
     </param>
     <param>
       <value>
-        <boolean>1</boolean>
-      </value>
-    </param>
-    <param>
-      <value>
-        <string></string>
-      </value>
-    </param>
-    <param>
-      <value>
         <string>securetoken99</string>
       </value>
     </param>

--- a/fixtures/get-systems-res.xml
+++ b/fixtures/get-systems-res.xml
@@ -36,13 +36,13 @@
                 <member>
                   <name>autoinstall_meta</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>
                   <name>kernel_options_post</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>
@@ -72,7 +72,7 @@
                 <member>
                   <name>kernel_options</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>
@@ -96,7 +96,7 @@
                 <member>
                   <name>template_files</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>
@@ -138,7 +138,7 @@
                 <member>
                   <name>boot_files</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>
@@ -224,7 +224,7 @@
                 <member>
                   <name>fetchable_files</name>
                   <value>
-                    <struct></struct>
+                    <string></string>
                   </value>
                 </member>
                 <member>

--- a/fixtures/get-template-file-req.xml
+++ b/fixtures/get-template-file-req.xml
@@ -9,16 +9,6 @@
     </param>
     <param>
       <value>
-        <boolean>1</boolean>
-      </value>
-    </param>
-    <param>
-      <value>
-        <string></string>
-      </value>
-    </param>
-    <param>
-      <value>
         <string>securetoken99</string>
       </value>
     </param>

--- a/profile.go
+++ b/profile.go
@@ -153,6 +153,9 @@ func (c *Client) CreateProfile(profile Profile) (*Profile, error) {
 		profile.VirtType = "<<inherit>>"
 	}
 
+	if profile.VirtDiskDriver == "" {
+		profile.VirtDiskDriver = "<<inherit>>"
+	}
 	/*
 
 		if system.PowerType == "" {


### PR DESCRIPTION
Changes

- added  `profile.VirtDiskDriver` to `profile.go` since Cobbler 3.x kept nagging in the acc tests for `terraform-provider-cobbler`.
- `make test` works after updating various fixtures.
